### PR TITLE
fix(schema): convert autoincrement ids to uids

### DIFF
--- a/prisma/data.ts
+++ b/prisma/data.ts
@@ -17,30 +17,30 @@ const users = [
             {
               ctc: "5.4LPA",
               offer_letter: "b",
-              event_id: 1,
+              event_id: "cl5q9t33d000009jiayn359rh",
             },
             {
               ctc: "9LPA",
               offer_letter: "d",
-              event_id: 4,
+              event_id: "cl5q9y1tq000309jig5lf1b6p",
             },
             {
               ctc: "7LPA",
               offer_letter: "e",
-              event_id: 5,
+              event_id: "cl5q9yius000409jid1bd9jek",
             },
           ],
         },
         applied_jobs: {
           create: [
             {
-              event_id: 1,
+              event_id: "cl5q9t33d000009jiayn359rh",
             },
             {
-              event_id: 4,
+              event_id: "cl5q9y1tq000309jig5lf1b6p",
             },
             {
-              event_id: 5,
+              event_id: "cl5q9yius000409jid1bd9jek",
             },
           ],
         },
@@ -116,30 +116,30 @@ const users = [
             {
               ctc: "5.4LPA",
               offer_letter: "a",
-              event_id: 1,
+              event_id: "cl5q9t33d000009jiayn359rh",
             },
             {
               ctc: "6LPA",
               offer_letter: "c",
-              event_id: 3,
+              event_id: "cl5q9ve0w000109jigyl0a9gw",
             },
             {
               ctc: "4LPA",
               offer_letter: "f",
-              event_id: 7,
+              event_id: "cl5q9z9c9000509ji2lu88334",
             },
           ],
         },
         applied_jobs: {
           create: [
             {
-              event_id: 1,
+              event_id: "cl5q9t33d000009jiayn359rh",
             },
             {
-              event_id: 3,
+              event_id: "cl5q9ve0w000109jigyl0a9gw",
             },
             {
-              event_id: 7,
+              event_id: "cl5q9z9c9000509ji2lu88334",
             },
           ],
         },
@@ -212,6 +212,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5q9t33d000009jiayn359rh",
           title: "Software Developement Trainee",
           ctc: "5.4 LPA",
           type: "full-time",
@@ -219,6 +220,7 @@ const companies = [
           eligibilityOfferCount: EligibiltyOfferCount.openforall,
         },
         {
+          id: "cl5q9xkej000209jif9r26qbs",
           title: "Software Developer",
           ctc: "6 LPA",
           type: "full-time",
@@ -234,6 +236,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5q9ve0w000109jigyl0a9gw",
           title: "Intern Developer",
           ctc: "3.2LPA",
           type: "internship",
@@ -241,6 +244,7 @@ const companies = [
           eligibilityOfferCount: EligibiltyOfferCount.atmost1,
         },
         {
+          id: "cl5q9y1tq000309jig5lf1b6p",
           title: "Software Developer",
           ctc: "8.1LPA",
           type: "intership + full-time",
@@ -256,6 +260,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5q9yius000409jid1bd9jek",
           title: "Nurse",
           ctc: "16 LPA",
           type: "full-time",
@@ -271,6 +276,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5q9z9c9000509ji2lu88334",
           title: "Graduate Engineer",
           ctc: "7 LPA",
           type: "full-time",
@@ -278,6 +284,7 @@ const companies = [
           eligibilityOfferCount: EligibiltyOfferCount.openforall,
         },
         {
+          id: "cl5qa02em000709ji33rw8cv3",
           title: "Graduate Trainee",
           ctc: "4 LPA",
           type: "full-time",
@@ -297,6 +304,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5qa1sc2000b09jie4foeleq",
           title: "AL Engineer",
           ctc: "6.6 LPA",
           type: "full-time",
@@ -312,6 +320,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5qa1jqe000a09jif2r00etu",
           title: "Tech Lead",
           ctc: "10 LPA",
           type: "full-time",
@@ -319,6 +328,7 @@ const companies = [
           eligibilityOfferCount: EligibiltyOfferCount.zero,
         },
         {
+          id: "cl5qa19vr000909ji52v66be6",
           title: "PPT Maker",
           ctc: "3 LPA",
           type: "internship",
@@ -334,6 +344,7 @@ const companies = [
     events: {
       create: [
         {
+          id: "cl5qa14kx000809jiaim1an2e",
           title: "Generalist",
           ctc: "5 LPA",
           type: "full-time",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,7 +68,6 @@ model user {
 }
 
 model student {
-  id        String      @id @default(cuid())
   name      String
   usn       String?     @unique
   branch    String?
@@ -87,24 +86,23 @@ model student {
 }
 
 model student_enrollment {
-  id        Int         @id @default(autoincrement())
   createdAt DateTime    @default(now())
   result    EventResult @default(pending)
 
-  event_id     Int
+  event_id     String
   event        event    @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
   student      student? @relation(fields: [studentEmail], references: [email])
-  studentEmail String?
+  studentEmail String
   @@unique([event_id, studentEmail])
 }
 
 model offer {
-  id           Int     @id @default(autoincrement())
+  id           String  @id @default(cuid())
   ctc          String
   offer_letter String  @unique
   studentEmail String
   student      student @relation(fields: [studentEmail], references: [email])
-  event_id     Int
+  event_id     String
   event        event   @relation(fields: [event_id], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }
 
@@ -183,7 +181,7 @@ model diploma {
 }
 
 model company {
-  id     Int     @id @default(autoincrement())
+  id     String  @id @default(cuid())
   name   String  @unique
   sector String
   events event[]
@@ -192,7 +190,7 @@ model company {
 }
 
 model event {
-  id                    Int                  @id @default(autoincrement())
+  id                    String               @id @default(cuid())
   createdAt             DateTime             @default(now())
   title                 String
   ctc                   String
@@ -202,7 +200,7 @@ model event {
   eligibilityOfferCount EligibiltyOfferCount
 
   offers     offer[]
-  company_id Int
+  company_id String
   company    company              @relation(fields: [company_id], references: [id])
   students   student_enrollment[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -62,7 +62,7 @@ const load = async () => {
       })
     );
 
-    console.log("Added companies data");
+    console.log("Added companies and events data");
 
     await Promise.all(
       users.map(async (user) => {
@@ -72,7 +72,9 @@ const load = async () => {
       })
     );
 
-    console.log("Added users data");
+    console.log(
+      "Added users,students,studentRecords,applied_jobs,offers,records,Sslcpuc,graduation,diploma data"
+    );
   } catch (e) {
     console.error(e);
     process.exit(1);


### PR DESCRIPTION
- remove ids where not required
- Converted autoincrements to uids as 
It could lead to a problem in a later stage if DB is sharded/distributed, where keeping track of last increment may not be possible.